### PR TITLE
allow specifying freetext extra arguments for readsb

### DIFF
--- a/rootfs/etc/services.d/readsb/run
+++ b/rootfs/etc/services.d/readsb/run
@@ -19,7 +19,9 @@ if [ -n "${MLATHOST}" ]; then
     READSB_CMD+=("--net-connector=${MLATHOST},${MLATPORT},beast_in")
 fi
 
-READSB_CMD+=("--net-connector=${BEASTHOST},${BEASTPORT},beast_in")
+if [ -n "${BEASTHOST}" ]; then
+    READSB_CMD+=("--net-connector=${BEASTHOST},${BEASTPORT},beast_in")
+fi
 
 READSB_CMD+=(--write-json=/run/readsb)
 READSB_CMD+=(--heatmap-dir /var/globe_history)
@@ -28,4 +30,5 @@ READSB_CMD+=(--json-trace-interval 15)
 READSB_CMD+=(--json-reliable 1)
 READSB_CMD+=("--max-range=$READSB_MAX_RANGE")
 
-"${READSB_BIN}" "${READSB_CMD[@]}" 2>&1 | awk -W Interactive '{print "[readsb] " $0}'
+# shellcheck disable=SC2086
+"${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS 2>&1 | awk -W Interactive '{print "[readsb] " $0}'


### PR DESCRIPTION
tested with this config for a net-connector to connect somewhere to get sbs data:
```
  tar1090:
    extra_hosts:
      - "host.docker.internal:host-gateway"
    image: mikenye/tar1090:latest
    tty: true
    container_name: tar1090
    restart: always
    environment:
      - UPDATE_TAR1090=false
      - TZ=${FEEDER_TZ}
      - LAT=${FEEDER_LAT}
      - LONG=${FEEDER_LONG}
      - TAR1090_DEFAULTCENTERLAT=${FEEDER_LAT}
      - TAR1090_DEFAULTCENTERLON=${FEEDER_LONG}
      - READSB_MAX_RANGE=0
      - READSB_EXTRA_ARGS= --net-connector host.docker.internal,43015,sbs_in --write-json-globe-index
    ports:
      - 8082:80
    volumes:
      - "tar1090_heatmap:/var/globe_history"
      - "tar1090_json:/run/readsb"

```
tested with this config for an sbs input listen port:
```
  tar1090:
    image: mikenye/tar1090:latest
    tty: true
    container_name: tar1090
    restart: always
    environment:
      - UPDATE_TAR1090=false
      - TZ=${FEEDER_TZ}
      - LAT=${FEEDER_LAT}
      - LONG=${FEEDER_LONG}
      - TAR1090_DEFAULTCENTERLAT=${FEEDER_LAT}
      - TAR1090_DEFAULTCENTERLON=${FEEDER_LONG}
      - READSB_MAX_RANGE=0
      - READSB_EXTRA_ARGS= --net-sbs-in-port 32106 --debug=n --write-json-globe-index
    ports:
      - 8082:80
      - 32106:32106
    volumes:
      - "tar1090_heatmap:/var/globe_history"
      - "tar1090_json:/run/readsb"
```