### PR TITLE
Extra information in aircraft.json file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
     READSB_GIT_URL="https://github.com/wiedehopf/readsb.git" \
     GITPATH_TAR1090=/opt/tar1090 \
     GITPATH_TAR1090_DB=/opt/tar1090-db \
+    GITPATH_TAR1090_AC_DB=/opt/tar1090-ac-db \
     HTTP_ACCESS_LOG="false" \
     HTTP_ERROR_LOG="true" \
     TAR1090_INSTALL_DIR=/usr/local/share/tar1090 \
@@ -89,6 +90,9 @@ RUN set -x && \
     mkdir -p /var/globe_history && \
     echo "readsb $(/usr/local/bin/readsb --version)" >> /VERSIONS && \
     popd && \
+    echo "========== Install AircraftDB ==========" && \
+    mkdir -p $GITPATH_TAR1090_AC_DB && \
+    curl https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz > $GITPATH_TAR1090_AC_DB/aircraft.csv.gz && \
     echo "========== Install s6-overlay ==========" && \
     curl -s https://raw.githubusercontent.com/mikenye/deploy-s6-overlay/master/deploy-s6-overlay.sh | sh && \
     # Versions

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ All of the variables below are optional.
 | `GZIP_LVL` | `1`-`9` are valid, lower lvl: less CPU usage, higher level: less network bandwidth used when loading the page | `3` |
 | `PTRACKS` | Shows the last `$PTRACKS` hours of traces you have seen at the `?pTracks` URL | `8` |
 | `TAR1090_FLIGHTAWARELINKS` | Set to any value to enable FlightAware links in the web interface | `null` |
+| `TAR1090_ENABLE_AC_DB` | Set to `true` to enable extra information, such as aircraft type and registration, to be included in in `aircraft.json` output. Will use more memory; use caution on older Pis or similiar devices. | `false` |
 
 #### `tar1090` `config.js` Configuration - Title
 

--- a/rootfs/etc/cont-init.d/02-tar1090-update
+++ b/rootfs/etc/cont-init.d/02-tar1090-update
@@ -20,6 +20,10 @@ if [ "${UPDATE_TAR1090}" = "true" ]; then
 	# Attempt to update tar1090
 	git fetch origin master > /dev/null 2>&1 || exit 0
 	git reset --hard origin/master > /dev/null 2>&1 || exit 0
+
+	# get the aircraft db file
+	rm -f $GITPATH_TAR1090_AC_DB/aircraft.csv.gz 
+	curl https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz > $GITPATH_TAR1090_AC_DB/aircraft.csv.gz || exit 0
 fi
 
 # Print tar1090 version

--- a/rootfs/etc/cont-init.d/02-tar1090-update
+++ b/rootfs/etc/cont-init.d/02-tar1090-update
@@ -22,8 +22,8 @@ if [ "${UPDATE_TAR1090}" = "true" ]; then
 	git reset --hard origin/master > /dev/null 2>&1 || exit 0
 
 	# get the aircraft db file
-	rm -f $GITPATH_TAR1090_AC_DB/aircraft.csv.gz 
-	curl https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz > $GITPATH_TAR1090_AC_DB/aircraft.csv.gz || exit 0
+	rm -f "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
+	curl https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz > "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz || exit 0
 fi
 
 # Print tar1090 version

--- a/rootfs/etc/cont-init.d/03-tar1090-copy
+++ b/rootfs/etc/cont-init.d/03-tar1090-copy
@@ -22,3 +22,4 @@ cp default "${TAR1090_INSTALL_DIR}"
 
 # Copy database
 cp -R "${GITPATH_TAR1090_DB}/db" "${TAR1090_INSTALL_DIR}/html"
+cp "$GITPATH_TAR1090_AC_DB/aircraft.csv.gz" "${TAR1090_INSTALL_DIR}"

--- a/rootfs/etc/services.d/readsb/run
+++ b/rootfs/etc/services.d/readsb/run
@@ -39,5 +39,12 @@ READSB_CMD+=(--net-bo-port=30005)
 READSB_CMD+=(--net-json-port=30047)
 READSB_CMD+=(--forward-mlat)
 
+# make sure the db file exists, and if it does, use it
+if [[ -e $TAR1090_INSTALL_DIR/aircraft.csv.gz ]]; then
+    if [[ "$TAR1090_ENABLE_AC_DB" == "true" ]]; then
+        READSB_CMD+=("--db-file=$TAR1090_INSTALL_DIR/aircraft.csv.gz")
+    fi
+fi
+
 # shellcheck disable=SC2086
 "${READSB_BIN}" "${READSB_CMD[@]}" $READSB_EXTRA_ARGS 2>&1 | awk -W Interactive '{print "[readsb] " $0}'


### PR DESCRIPTION
Functionality to enable the output of aircraft.db.gz data, such as a/c type and registration, in the aircraft.json output. Disabled by default due to increased memory usage, and can be enabled by setting `TAR1090_ENABLE_AC_DB` to `true`.