### PR TITLE
Fix container startup failures if curl downloads fail

### DIFF
--- a/rootfs/etc/cont-init.d/02-tar1090-update
+++ b/rootfs/etc/cont-init.d/02-tar1090-update
@@ -31,7 +31,7 @@ if [ "${UPDATE_TAR1090}" = "true" ]; then
     # copy new aircraft db file in to place
 	if [[ -e /aircraft.csv.gz ]]; then
 		rm -f "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
-		mv /aircraft.csv.gz rm "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
+		mv /aircraft.csv.gz "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
 	fi
 fi
 

--- a/rootfs/etc/cont-init.d/02-tar1090-update
+++ b/rootfs/etc/cont-init.d/02-tar1090-update
@@ -22,8 +22,17 @@ if [ "${UPDATE_TAR1090}" = "true" ]; then
 	git reset --hard origin/master > /dev/null 2>&1 || exit 0
 
 	# get the aircraft db file
-	rm -f "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
-	curl https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz > "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz || exit 0
+	curl \
+		--silent \
+		--output /aircraft.csv.gz \
+		https://raw.githubusercontent.com/wiedehopf/tar1090-db/csv/aircraft.csv.gz  || \
+		echo "Failed to download updated aircraft database. Using cached version"
+
+    # copy new aircraft db file in to place
+	if [[ -e /aircraft.csv.gz ]]; then
+		rm -f "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
+		mv /aircraft.csv.gz rm "$GITPATH_TAR1090_AC_DB"/aircraft.csv.gz
+	fi
 fi
 
 # Print tar1090 version

--- a/rootfs/etc/cont-init.d/06-range-outline
+++ b/rootfs/etc/cont-init.d/06-range-outline
@@ -5,7 +5,7 @@
 if [ -n "${HEYWHATSTHAT_PANORAMA_ID}" ]; then
     curl \
         --silent \
-        --output ~/upintheair.json \
+        --output /usr/local/share/tar1090/html/upintheair.json \
         "http://www.heywhatsthat.com/api/upintheair.json?id=${HEYWHATSTHAT_PANORAMA_ID}&refraction=0.25&alts=12192" || \
         echo "WARNING: Unable to download panorama. Outline will not be available."; exit 0
 fi

--- a/rootfs/etc/cont-init.d/06-range-outline
+++ b/rootfs/etc/cont-init.d/06-range-outline
@@ -5,6 +5,7 @@
 if [ -n "${HEYWHATSTHAT_PANORAMA_ID}" ]; then
     curl \
         --silent \
-        --output /usr/local/share/tar1090/html/upintheair.json \
-        "http://www.heywhatsthat.com/api/upintheair.json?id=${HEYWHATSTHAT_PANORAMA_ID}&refraction=0.25&alts=12192"
+        --output ~/upintheair.json \
+        "http://www.heywhatsthat.com/api/upintheair.json?id=${HEYWHATSTHAT_PANORAMA_ID}&refraction=0.25&alts=12192" || \
+        echo "WARNING: Unable to download panorama. Outline will not be available."; exit 0
 fi


### PR DESCRIPTION
Updates the following:

* tar1090 aircraft database download output is silenced
* tar1090 aircraft database cached copy is not deleted until download success
* tar1090 aircraft database is moved in to place after download success
* Hey what's that panorama ID download exits 0 with a warning if it fails to download

While playing around with this I noted that on my Mac curl by default either has a super long timeout or no time out at all. Would it be worth adding `--max-time 20` to the curl commands, or something like that, to make sure the startup doesn't hang?