### PR TITLE
Stop Timelapse from starting until readsb is done

### DIFF
--- a/rootfs/etc/services.d/timelapse1090/run
+++ b/rootfs/etc/services.d/timelapse1090/run
@@ -14,7 +14,11 @@ if [[ -n "$ENABLE_TIMELAPSE1090" ]]; then
     echo "CHUNK_SIZE=$TIMELAPSE1090_CHUNK_SIZE"
   } > /etc/default/timelapse1090
 
-  pushd /opt/timelapse1090 || exit 1
+  pushd /opt/timelapse1090 >/dev/null || exit 1
+
+  while [[ ! -e /run/readsb/receiver.json ]]; do
+    sleep 10
+  done
 
   /opt/timelapse1090/timelapse1090.sh \
     2>&1 | awk -W interactive '{print "[timelapse1090] " $0}'


### PR DESCRIPTION
Will stop erroneous error log messages from appearing during container start.

* pushd output in timelapse startup is sent to `/dev/null`
* Wait until /run/readsb/receiver.json is found before continuing timelapse startup